### PR TITLE
JSON編碼選項和輸出人形技能等級

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,18 +6,22 @@ import itertools
 import math
 import pulp as lp
 import argparse
+from prettytable import PrettyTable
+
 # %% argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('theater_id',default='748',type=str,help='关卡id,如736代表第7期高级区第6关')
 parser.add_argument('-m','--max_dolls',type=int,default=30,help='上场人数')
 parser.add_argument('-f','--fairy_ratio',type=float,default=1.25,help='妖精加成,默认5星1.25')
 parser.add_argument('-u','--upgrade_resource',type=int,default=0,help='可以用于强化的资源量（普通装备消耗1份，专属消耗3份）')
+parser.add_argument('-e','--encoding',type=str,default='gbk',help='encoding used in user_info.json')
 args = parser.parse_args()
 # %% 战区关卡参数
 theater_id = args.theater_id  # 关卡id,如736代表第7期第3区域第6关
 fairy_ratio = args.fairy_ratio  # 妖精加成：5星1.25
 max_dolls = args.max_dolls  # 上场人数
 upgrade_resource = args.upgrade_resource # 可以用于强化的资源量（普通装备消耗1份，专属消耗3份）
+userinfo_encoding = args.encoding # workaround the issue where people feeds the script with json in various encodings
 
 # %%
 theater_config = get_theater_config(theater_id)
@@ -25,7 +29,7 @@ theater_config['max_dolls'] = max_dolls
 theater_config['fairy_ratio'] = fairy_ratio
 # %%
 name_table = get_name_table()
-doll_info, equip_info, my_dolls, my_equips = load_info()
+doll_info, equip_info, my_dolls, my_equips = load_info(userinfo_encoding)
 # %% 计算各人形不同配装的效能
 choices = prepare_choices(doll_info, equip_info, my_dolls, my_equips, theater_config)
 # %%
@@ -65,6 +69,11 @@ for k, v in lp_vars.items():
 res.sort(key=lambda x: x[1], reverse=True)
 for r in strn:
     print(r[0], r[1],sep='\t')
+dollTable = PrettyTable()
+dollTable.field_names = ["Doll Name", "Equipment 1", "Eq 1 LV", "Equipment 2", "Eq 2 LV", "Equipment 3", "Eq 3 LV", "Skill1 LV", "Skill2 LV", "Score"]
 for r in res:
-    print(r[0], r[1],sep='\t')
+    row_data = r[0].split(sep='\t')
+    row_data.append(r[1])
+    dollTable.add_row(row_data)
+print(dollTable)
 # %%

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ujson
 pulp
+prettytable

--- a/utils.py
+++ b/utils.py
@@ -25,14 +25,20 @@ def get_theater_config(theater_id='724'):
     }
 
 # %%
-def load_info():
+def load_info(userinfo_encoding='utf-8'):
     name_table = get_name_table()
     with open(r'resource/doll.json','r',encoding='utf-8') as f:
         doll_info = ujson.load(f)
     with open(r'resource/equip.json','r',encoding='utf-8') as f:
         equip_info = ujson.load(f)
-    with open(r'info/user_info.json','r',encoding='gbk') as f:
-        user_info = ujson.load(f)
+    with open(r'info/user_info.json','r',encoding=userinfo_encoding) as f:
+        try:
+            user_info = ujson.load(f)
+        except UnicodeDecodeError:
+            print(f'user_info.json does not seem to be encoded in {userinfo_encoding}, '
+                  f'try specifying the correct encoding with -e option')
+            exit(1)
+
     # %% 统计持有人形信息
     my_dolls = {}
     for doll in doll_info.values():
@@ -135,7 +141,8 @@ def prepare_choices(doll_info, equip_info, my_dolls, my_equips, theater_config):
             sp_ratio = 1.2 if id % 20000 in advantage else 1
             score = math.floor(class_weight[doll['type']]*sp_ratio*fairy_ratio*strength[fight_mode]/100)
             # print(name_table[i[0]['name']],i[1],name_table[j[0]['name']],j[1],name_table[k[0]['name']],k[1],score)
-            recipe_name = f"{my_dolls[id]['name']}\t{name_table[i[0]['name']]}\t{i[1]}\t{name_table[j[0]['name']]}\t{j[1]}\t{name_table[k[0]['name']]}\t{k[1]}"
+            recipe_name = f"{my_dolls[id]['name']}\t{name_table[i[0]['name']]}\t{i[1]}\t{name_table[j[0]['name']]}\t{j[1]}\t{name_table[k[0]['name']]}\t{k[1]}" \
+                          f"\t{my_dolls[id]['skill1']}\t{my_dolls[id]['skill2'] if my_dolls[id]['skill2'] > 0 else 'NA'}"
             recipe_content = {
                 my_dolls[id]['name']:-1,
                 f"{name_table[i[0]['name']]}_{i[1]}":-1,


### PR DESCRIPTION
你好,

這邊有台服玩家用GFAlarm輸出遊戲資料，結果拿到了一個big5編碼的json，所以我想說加上一個CLI參數來指定編碼或許會比直接更改腳本內容簡單。

因為這邊沒有在用GFAlarm也沒有拿到該玩家的json，測試方面只有用notepad++轉變編碼為big5/gb2312和更改指揮官名稱成對應的中文字串來驗證。

![image](https://user-images.githubusercontent.com/46232230/163660066-0748fe46-f92f-4b84-b650-4962ce6ba4b6.png)
另外我個人有一大堆人型技能等級都沒有滿級，我就乾脆也把這部分也加進最終顯示資料的部分，就是不知道對其他玩家來說實不實用。