### PR TITLE
支持在其他目錄下執行腳本

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ from utils import *
 import pulp as lp
 import argparse
 from prettytable import PrettyTable
-import os
 
 # %% argparse
 parser = argparse.ArgumentParser()
@@ -60,9 +59,8 @@ for k, v in resource.items():
     problem += v >= 0, k
 problem += resource['score'] + 0.001*resource['强化资源']
 
-lp_bin_rel = lp.core.pulp_cbc_path.split('solverdir\\')[-1]
-lp_bin_abs = os.path.join(os.getcwd(), 'solverdir', lp_bin_rel)
-problem.solve(lp.COIN_CMD(msg=0,path=lp_bin_abs))
+lp_bin_abs=Path(__file__).resolve().parent/'solverdir'/(lp.core.pulp_cbc_path.split('solverdir\\')[-1])
+problem.solve(lp.COIN_CMD(msg=0,path=str(lp_bin_abs)))
 
 print(f"总效能: {resource['score'].value():.0f}")
 strn_table = PrettyTable(['强化装备','数量'])

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,7 @@ import csv
 import math
 import ujson
 import itertools
+from pathlib import Path
 # %%
 def get_name_table(language: str = "zh-CN"):
     """
@@ -12,7 +13,7 @@ def get_name_table(language: str = "zh-CN"):
     :param language: IETF language tag defined in the header of that tsv
     :return: name_table or the corresponding language if found
     """
-    with open(r'resource/table.tsv','r',encoding='utf-8') as f:
+    with open(Path(__file__).resolve().parent/r'resource/table.tsv', 'r', encoding='utf-8') as f:
         name_table = {}
         try:
             for row in csv.DictReader(f, delimiter='\t'):
@@ -41,7 +42,7 @@ def get_translation(entry: str, name_table: dict):
 
 # %%
 def get_theater_config(theater_id='724'):
-    with open(r'resource/theater_info.json','r',encoding='utf-8') as f:
+    with open(Path(__file__).resolve().parent/r'resource/theater_info.json', 'r', encoding='utf-8') as f:
         theater_info = ujson.load(f)
         theater = theater_info[theater_id]
     types = ['HG','SMG','RF','AR','MG','SG']
@@ -54,11 +55,11 @@ def get_theater_config(theater_id='724'):
 
 # %%
 def load_info():
-    with open(r'resource/doll.json','r',encoding='utf-8') as f:
+    with open(Path(__file__).resolve().parent/r'resource/doll.json', 'r', encoding='utf-8') as f:
         doll_info = ujson.load(f)
-    with open(r'resource/equip.json','r',encoding='utf-8') as f:
+    with open(Path(__file__).resolve().parent/r'resource/equip.json', 'r', encoding='utf-8') as f:
         equip_info = ujson.load(f)
-    with open(r'info/user_info.json','rb') as f:
+    with open(Path(__file__).resolve().parent/r'info/user_info.json', 'rb') as f:
         user_info = ujson.decode(f.read().decode("ascii", "ignore"))
     # with open(r'info/user_info.json','r',encoding='gbk',errors='ignore') as f:
         # user_info = ujson.load(f)


### PR DESCRIPTION
改成在執行時判斷絕對路徑後再調用各個API，只有在Win 10/ Ubuntu 18.04 LTS x64下測試過。

教來教去後覺得還是直接這樣做比較快。
```

D:\>py -3.10 C:\temp\GF_Theater_Commander\main.py 848 -m 30 -f 2 -l zh-TW -u5
总效能: 78177
+------------+------+
|  强化装备  | 数量 |
+------------+------+
| #2運算晶片 |  4   |
+------------+------+
+-------------+-----------------+-------+-------------------+-------+----------------+-------+------+
|     人形    |      装备1      | 强化1 |       装备2       | 强化2 |     装备3      | 强化3 | 效能 |
+-------------+-----------------+-------+-------------------+-------+----------------+-------+------+
|     M4A1    |     PEQ-16A     |     0 |     APCR高速彈    |    10 |  遺留的武器庫  |    10 | 3153 |
|    AN-94    |     PEQ-16A     |     0 |     APCR高速彈    |    10 |   #2運算晶片   |    10 | 2896 |
```