### PR TITLE
优先按效能排序

### DIFF
--- a/main.py
+++ b/main.py
@@ -313,7 +313,7 @@ class TheaterCommander(tk.Tk):
         self.lbl_total_score.config(text=_("总效能：") + f"{total_score:>6}")
 
         g_records.sort(
-            key=lambda r: (-r["type_id"], r["level"], r["rank"], r["idx"]), reverse=True
+            key=lambda r: (r["score"], -r["type_id"], r["level"], r["rank"], r["idx"]), reverse=True
         )
         for frame in self.gun_frame:
             frame.destroy()


### PR DESCRIPTION
优先按照效能排序后编辑人形装备时，能够更容易利用效能值发现没有合适装备的人形